### PR TITLE
New case in Cape Town school

### DIFF
--- a/data/covid19za_timeline_confirmed.csv
+++ b/data/covid19za_timeline_confirmed.csv
@@ -23,3 +23,4 @@ date,country,province,age,gender,transmission_type
 13-03-2020,South Africa,KZN,52,male,Travelled to Switzerland
 13-03-2020,South Africa,WC,50,male,Travelled to Switzerland and Austria
 13-03-2020,South Africa,WC,46,male,Travelled to Italy
+14-03-2020,South Africa,WC,13,Female,Travelled overseas


### PR DESCRIPTION
https://m.news24.com/SouthAfrica/News/coronavirus-cape-town-school-confirms-grade-9-tests-positive-for-covid-19-20200314