### PR TITLE
Add Dockerfile to build an image to simplify API deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# I've decided to use a multi-stage docker build to allow for the posibility to add a front-end in the future
+# This also ensures that the container we ship only contains productions code - (no build time dependencies)
+
+# ---- Build the api ----
+FROM golang:alpine AS apibuilder
+WORKDIR $HOME/etc/api
+COPY api/ ./
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /api .
+
+# ---- Final Image with api ----
+FROM alpine:latest
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+COPY --from=apibuilder /api ./api
+RUN chmod +x ./api
+CMD ["./api"]

--- a/api/main.go
+++ b/api/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/dsfsi/covid19za/api/controllers"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -10,7 +9,7 @@ import (
 	"os"
 )
 
-func main()  {
+func main() {
 	api := echo.New()
 	api.Use(middleware.Logger())
 	api.Use(middleware.Recover())
@@ -35,7 +34,7 @@ func main()  {
 func determineListenAddress() (string, error) {
 	port := os.Getenv("PORT")
 	if port == "" {
-		return "", fmt.Errorf("$PORT not set")
+		return ":5000" + port, nil
 	}
 	return ":" + port, nil
 }

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+    worker:
+      dockerfile: Dockerfile


### PR DESCRIPTION
 - Update main.go to default to PORT 5000 when PORT is not set
 - Add Dockerfile
 - Add heroku.yml to tell Heroku how to deploy the application