### PR TITLE
fix(README): correct link to coronamap repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Code [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](http
 ## Visualisation
 * Google Data Studio Dashboard [URL link](https://datastudio.google.com/reporting/1b60bdc7-bec7-44c9-ba29-be0e043d8534)
 ![Dashboard](/visualisation/dashboard.png)
-* Coronavirus Map [[Website](https://coronamap.co.za)] [[GitHub Repo](https://coronamap.co.za)]
+* Coronavirus Map [[Website](https://coronamap.co.za)] [[GitHub Repo](https://github.com/JayWelsh/coronamap)]
 ![Dashboard](/visualisation/coronamap.png)
 ## Data Sources:
 * NICD - South Africa [URL](http://www.nicd.ac.za/media/alerts/)


### PR DESCRIPTION
Correcting a mistake I made with the GitHub link to the coronamap repo. Sorry about that. :)