### PR TITLE
Caching for API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,24 @@
 # ---- Build the api ----
 FROM golang:alpine AS apibuilder
 WORKDIR $HOME/etc/api
-COPY api/ ./
+# Start by copying just the parts needed for go mod download, so that source
+# changes don't trigger re-download.
+COPY api/go.mod ./go.mod
+COPY api/go.sum ./go.sum
 RUN go mod download
+COPY api/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /api .
 
-# ---- Final Image with api ----
+# ---- Final Image with api and varnish ----
 FROM alpine:latest
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates varnish supervisor
+COPY docker/supervisord.conf /etc/supervisord.conf
+COPY docker/varnish/default.vcl /etc/varnish/default.vcl
 COPY --from=apibuilder /api ./api
 RUN chmod +x ./api
-CMD ["./api"]
+# Heroku runs Docker containers as non-root user, so do the same locally for
+# testing.
+RUN adduser -D apiuser
+RUN chown -R apiuser /var/lib/varnish /etc/varnish
+USER apiuser
+CMD ["/usr/bin/supervisord"]

--- a/api/main.go
+++ b/api/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"flag"
 	"github.com/dsfsi/covid19za/api/controllers"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
-	"flag"
 	"log"
 	"net/http"
 	"os"

--- a/api/main.go
+++ b/api/main.go
@@ -14,6 +14,13 @@ const (
 	dataSetBaseUrl = "https://raw.githubusercontent.com/dsfsi/covid19za/master/data/"
 )
 
+func cacheControl(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set("Cache-control", "public, max-age=120")
+		return next(c)
+	}
+}
+
 func makeAPI(baseUrl string) *echo.Echo {
 	api := echo.New()
 	api.Use(middleware.Logger())
@@ -22,6 +29,7 @@ func makeAPI(baseUrl string) *echo.Echo {
 	api.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		Level: 5,
 	}))
+	api.Use(cacheControl)
 
 	latestUpdateController := controllers.NewLatestUpdateController()
 	caseController := controllers.NewCaseController(baseUrl)

--- a/api/main.go
+++ b/api/main.go
@@ -43,13 +43,18 @@ func makeAPI(baseUrl string) *echo.Echo {
 
 func main() {
 	baseUrlPtr := flag.String("base-url", dataSetBaseUrl, "Base URL from which to retrieve data")
+	bindPtr := flag.String("bind", "", "Address to listen on")
 	flag.Parse()
 
 	api := makeAPI(*baseUrlPtr)
 
-	addr, err := determineListenAddress()
-	if err != nil {
-		log.Fatal(err)
+	addr := *bindPtr
+	if addr == "" {
+		var err error
+		addr, err = determineListenAddress()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	log.Printf("Listening on %s...\n", addr)
@@ -59,7 +64,7 @@ func main() {
 func determineListenAddress() (string, error) {
 	port := os.Getenv("PORT")
 	if port == "" {
-		return ":5000" + port, nil
+		return ":5000", nil
 	}
 	return ":" + port, nil
 }

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,17 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/dev/null
+
+[program:varnish]
+command=/usr/sbin/varnishd -a :%(ENV_PORT)s,HTTP -F -f /etc/varnish/default.vcl
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:api]
+command=/api --bind 127.0.0.1:8081
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0

--- a/docker/varnish/default.vcl
+++ b/docker/varnish/default.vcl
@@ -1,0 +1,12 @@
+vcl 4.0;
+
+backend default {
+    .host = "127.0.0.1";
+    .port = "8081";
+}
+
+sub vcl_recv {
+    # Headers that prevent Varnish from caching, and are not used.
+    unset req.http.Authorization;
+    unset req.http.Cookie;
+}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,5 +1,3 @@
 build:
   docker:
     web: Dockerfile
-    worker:
-      dockerfile: Dockerfile


### PR DESCRIPTION
This makes two changes:

1. Add Cache-control header to all responses, specifying caching for 2 minutes. Clients that do their own caching (particularly browsers) will then reuse the response, even if a Javascript app is polling more often.
2. Add Varnish in front of the application. Varnish will cache responses for 2 minutes and serve them to all clients that aren't doing their own caching. This will still put a little load on the web dyno, but much less than before because it just needs to dump the cached response on the wire rather than fetching CSV from Github and transforming it into JSON.

@Remwrath @Vutlhari this is probably of interest to you.