### PR TITLE
Add GeoSubdivision to public hospitals API

### DIFF
--- a/api/main_test.go
+++ b/api/main_test.go
@@ -21,6 +21,7 @@ var (
 		"district":              "eThekwini Metropolitan Municipality",
 		"Subdistrict":           "eThekwini MM Sub",
 		"DistrictEstPopulation": "3702231",
+		"GeoSubdivision":        "ZA-KZN",
 	}
 	expectedPrivateHospital = map[string]interface{}{
 		"Id":        "464",

--- a/api/models/public_hospitals.go
+++ b/api/models/public_hospitals.go
@@ -15,6 +15,7 @@ type PublicHospital struct {
 	NumberOfBeds          string `json:"NumberOfBeds" csv:"number_of_beds"`
 	NumberOfPractitioners string `json:"NumberOfPractitioners" csv:"number_of_practitioners"`
 	Webpage               string `json:"Webpage" csv:"webpage"`
+	GeoSubdivision        string `json:"GeoSubdivision" csv:"geo_subdivision"`
 }
 
 type PublicHospitals []PublicHospital


### PR DESCRIPTION
PR #211 added this field to the CSV file; this PR mirrors it in the
returned data from the API. See #187.