### PR TITLE
Prepare Docker image for Heroku SSH tunneling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ COPY api/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o /api .
 
 # ---- Final Image with api and varnish ----
+# bash, curl, openssh and python are for Heroku's ssh tunnel
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates varnish supervisor
+RUN apk --no-cache add ca-certificates varnish supervisor bash curl openssh python
+COPY docker/heroku-exec.sh /app/.profile.d/
+RUN ln -sf /bin/bash /bin/sh
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/varnish/default.vcl /etc/varnish/default.vcl
 COPY --from=apibuilder /api ./api

--- a/docker/heroku-exec.sh
+++ b/docker/heroku-exec.sh
@@ -1,0 +1,1 @@
+[ -z "$SSH_CLIENT" ] && source <(curl --fail --retry 3 -sSL "$HEROKU_EXEC_URL")


### PR DESCRIPTION
This allows `heroku ps:exec` to work, which can be used to run utilities like varnishstat and varnishtop to do basic monitoring of the service. Based on https://devcenter.heroku.com/articles/exec#using-with-docker

@Vutlhari