### PR TITLE
Update provincial_mp_cumulative.csv

### DIFF
--- a/data/district_data/provincial_mp_cumulative.csv
+++ b/data/district_data/provincial_mp_cumulative.csv
@@ -71,4 +71,4 @@ date,YYYYMMDD,bushbuckridge,mbombela,nkomazi,thaba_chweru,albert_luthuli,dipalis
 15-05-2020,20200515,1,13,20,1,0,0,16,3,2,0,1,1,2,2,2,3,0,0,67,44,https://twitter.com/MpuHealth1
 16-05-2020,20200516,1,13,20,1,0,0,16,3,2,0,1,1,2,3,2,3,0,0,68,49,https://twitter.com/MpuHealth1
 17-05-2020,20200517,1,14,20,1,0,0,16,3,2,0,1,1,2,5,2,3,0,0,71,49,https://twitter.com/MpuHealth1
-18-05-2020,20200518,,,,,,,,,,,,,,,,,,,76,53,https://twitter.com/nicd_sa
+18-05-2020,20200518,1,14,20,1,1,0,16,4,2,0,1,1,2,5,2,3,0,0,73,53,https://twitter.com/MpuHealth1. Total differs from NICD total by 3 cases misallocated according to MpuHealth.


### PR DESCRIPTION
Still 18 May. DIstrict data updated, but differs from national total (Mpumalanga total now 73, according to provincial health department, compared to NICD number of 76).