### PR TITLE
Github Action and script to scrape vaccination numbers

### DIFF
--- a/.github/workflows/vaccinations_scraper.yml
+++ b/.github/workflows/vaccinations_scraper.yml
@@ -1,0 +1,33 @@
+name: Scrape provincial vaccinations data from sacoronavirus.co.za
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.6' 
+      - name: Install pandas
+        run: pip install pandas 
+      - name: Install requests
+        run: pip install requests 
+      - name: Scrape data 
+        run: cd scripts/;python sacoronavirus_provincial_vaccine.py
+      - name: Commit changes
+        run: |
+          git config --local user.name github-actions
+          git config --local user.email "action@github.com"
+          git add data/covid19za_provincial_cumulative_timeline_vaccination.csv
+          if [[ "$(git status --porcelain)" != "" ]]; then
+              git commit -m "Update Provincial Vaccinations Data" -a
+              git push origin provincial_vaccine_data
+          fi
+        env:
+          REPO_KEY: ${{secrets.GITHUB_TOKEN}}
+          username: github-actions

--- a/scripts/cumulative.json
+++ b/scripts/cumulative.json
@@ -1,0 +1,99 @@
+{
+    "version": "1.0.0",
+    "queries": [
+        {
+            "Query": {
+                "Commands": [
+                    {
+                        "SemanticQueryDataShapeCommand": {
+                            "Query": {
+                                "Version": 2,
+                                "From": [
+                                    {
+                                        "Name": "e1",
+                                        "Entity": "rtc za_covid19_vaccinations_summary_province_p_v1_vw_vw_vw",
+                                        "Type": 0
+                                    }
+                                ],
+                                "Select": [
+                                    {
+                                        "Column": {
+                                            "Expression": {
+                                                "SourceRef": {
+                                                    "Source": "e1"
+                                                }
+                                            },
+                                            "Property": "visit_date"
+                                        },
+                                        "Name": "evds za_covid19_vaccinations_summary_province_v3_vw_vw.visit_date.Variation.Date Hierarchy.Year"
+                                    },
+                                    {
+                                        "Measure": {
+                                            "Expression": {
+                                                "SourceRef": {
+                                                    "Source": "e1"
+                                                }
+                                            },
+                                            "Property": "Cumulative Vaccinations"
+                                        },
+                                        "Name": "tc za_covid19_vaccinations_summary_province_p_v1_vw_vw_vw.Cumulative Vaccinations"
+                                    }
+                                ],
+                                
+                                "OrderBy": [
+                                    {
+                                        "Direction": 1,
+                                        "Expression": {
+                                            "Column": {
+                                                "Expression": {
+                                                    "SourceRef": {
+                                                        "Source": "e1"
+                                                    }
+                                                },
+                                                "Property": "visit_date"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "Binding": {
+                                "Primary": {
+                                    "Groupings": [
+                                        {
+                                            "Projections": [
+                                                0,
+                                                1
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "DataReduction": {
+                                    "DataVolume": 4,
+                                    "Primary": {
+                                        "Window": {
+                                            "Count": 1000
+                                        }
+                                    }
+                                },
+                                "Version": 1
+                            },
+                            "ExecutionMetricsKind": 1
+                        }
+                    }
+                ]
+            },
+            "QueryId": "",
+            "ApplicationContext": {
+                "DatasetId": "6f42ba54-a8f6-46a6-afab-bedcd3dd1563",
+                "Sources": [
+                    {
+                        "ReportId": "f31bda4b-2754-475d-ad4b-e7ae4e213621",
+                        "VisualId": "36d9f1d12796cf44049f"
+                    }
+                ]
+            }
+        }
+    ],
+    "cancelQueries": [],
+    "modelId": 4449930
+}

--- a/scripts/prov_filter.json
+++ b/scripts/prov_filter.json
@@ -1,0 +1,27 @@
+{
+    "Condition": {
+        "In": {
+            "Expressions": [
+                {
+                    "Column": {
+                        "Expression": {
+                            "SourceRef": {
+                                "Source": "e1"
+                            }
+                        },
+                        "Property": "province"
+                    }
+                }
+            ],
+            "Values": [
+                [
+                    {
+                        "Literal": {
+                            "Value": ""
+                        }
+                    }
+                ]
+            ]
+        }
+    }
+}

--- a/scripts/sacoronavirus_provincial_vaccine.py
+++ b/scripts/sacoronavirus_provincial_vaccine.py
@@ -1,0 +1,80 @@
+import requests
+import json
+from datetime import datetime
+import pandas as pd
+
+headers = {
+    "accept": "application/json, text/plain, */*",
+    "accept-language": "en-GB,en-US;q=0.9,en;q=0.8,en-ZA;q=0.7",
+    "activityid": "cc2d2d94-b0ce-4b98-8b75-cc50f2ca3e18",
+    "cache-control": "no-cache",
+    "content-type": "application/json;charset=UTF-8",
+    "pragma": "no-cache",
+    "requestid": "5cbdc7c5-eaf9-3645-2918-50eae987eaac",
+    "sec-ch-ua": "\" Not;A Brand\";v=\"99\", \"Google Chrome\";v=\"91\", \"Chromium\";v=\"91\"",
+    "sec-ch-ua-mobile": "?0",
+    "sec-fetch-dest": "empty",
+    "sec-fetch-mode": "cors",
+    "sec-fetch-site": "cross-site",
+    "x-powerbi-resourcekey": "03e532ee-b92a-44a5-9be9-d28054e54995"
+}
+
+def get_prov_filter(prov):
+     with open(f'prov_filter.json') as file:
+         prov_filter = json.loads(file.read())
+         prov_filter['Condition']['In']['Values'][0][0]['Literal']['Value'] = f"'{prov}'"
+         return prov_filter
+
+def ensure_cols_numeric(df, cols):
+    for col in cols:
+        df[col] = pd.to_numeric(df[col], errors='coerce').astype('Int64')
+
+def fetch_source(data_set, label, filter = None):
+    with open(f'cumulative.json') as req:
+        content = req.read()
+        body = json.loads(content)
+        if filter:
+            body['queries'][0]['Query']['Commands'][0]['SemanticQueryDataShapeCommand']['Query']['Where'] = [filter]
+
+        res = requests.post("https://wabi-west-europe-api.analysis.windows.net/public/reports/querydata?synchronous=true",headers=headers, json=body)
+        data = res.json()
+        rows = data["results"][0]["result"]["data"]["dsr"]["DS"][0]["PH"][0]["DM0"]
+
+        # print(json.dumps(data, indent=4))
+
+        for r in rows:
+            data = r['C']
+            date = datetime.fromtimestamp(data[0]/1000)
+            date_str = date.strftime("%Y-%m-%d")
+
+            if not date_str in data_set:
+                data_set[date_str] = {
+                    'date': date_str,
+                    'YYYYMMDD': date.strftime("%Y%m%d")
+                }
+
+            data_set[date_str][label] =  data[1]
+            
+data_set = {}
+
+fetch_source(data_set, "GP", get_prov_filter('Gauteng'))
+fetch_source(data_set, "WC", get_prov_filter('Western Cape'))
+fetch_source(data_set, "EC", get_prov_filter('Eastern Cape'))
+fetch_source(data_set, "FS", get_prov_filter('Free State'))
+fetch_source(data_set, "KZN", get_prov_filter('KwaZulu-Natal'))
+fetch_source(data_set, "LP", get_prov_filter('Limpopo'))
+fetch_source(data_set, "MP", get_prov_filter('Mpumalanga'))
+fetch_source(data_set, "NW", get_prov_filter('North West'))
+fetch_source(data_set, "NC", get_prov_filter('Northern Cape'))
+fetch_source(data_set, "total")
+
+df = pd.DataFrame.from_records(list(data_set.values()))
+df = df.sort_values(by=['date'])
+
+ensure_cols_numeric(df, ['EC', 'FS', 'GP', 'KZN', 'LP', 'MP', 'NC', 'NW', 'WC', 'total'])
+
+df['source'] = "https://sacoronavirus.co.za/latest-vaccine-statistics/"
+
+df = df[['date', 'YYYYMMDD', 'EC', 'FS', 'GP', 'KZN', 'LP', 'MP', 'NC', 'NW', 'WC', 'total', 'source']]
+
+df.to_csv('../data/covid19za_provincial_cumulative_timeline_vaccination.csv', index=False)


### PR DESCRIPTION
This PR adds the script and Github Action for scraping vaccination numbers from https://sacoronavirus.co.za/latest-vaccine-statistics/ to the file data/covid19za_provincial_cumulative_timeline_vaccination.csv. This is so we don't need to create daily PR's for new data.

The current schedule is to run every day at 5am, but this can be changed.